### PR TITLE
Abh update warnings

### DIFF
--- a/lib/cc/yaml/nodes/mapping.rb
+++ b/lib/cc/yaml/nodes/mapping.rb
@@ -1,7 +1,7 @@
 module CC::Yaml
   module Nodes
     class Mapping < Node
-      INCOMPATIBLE_KEYS_WARNING = "Warning: Use either a Languages key or an Engines key, but not both. They are mutually exclusive.".freeze
+      INCOMPATIBLE_KEYS_WARNING = "Use either a Languages key or an Engines key, but not both. They are mutually exclusive.".freeze
 
       def self.mapping
         @mapping ||= superclass.respond_to?(:mapping) ? superclass.mapping.dup : {}

--- a/lib/cc/yaml/nodes/mapping.rb
+++ b/lib/cc/yaml/nodes/mapping.rb
@@ -1,7 +1,7 @@
 module CC::Yaml
   module Nodes
     class Mapping < Node
-      INCOMPATIBLE_KEYS_WARNING = "Analysis settings for Languages and Engines are both valid but mutually exclusive. Note: command line analysis requires an Engines configuration.".freeze
+      INCOMPATIBLE_KEYS_WARNING = "Warning: Use either a Languages key or an Engines key, but not both. They are mutually exclusive.".freeze
 
       def self.mapping
         @mapping ||= superclass.respond_to?(:mapping) ? superclass.mapping.dup : {}
@@ -187,19 +187,7 @@ module CC::Yaml
 
       def check_incompatibility(key)
         if creates_incompatibility?(key)
-          warning(incompatibility_message(key), key)
-        end
-      end
-
-      def incompatibility_message(key)
-        "#{extant_engines_or_languages_key} key already found, dropping key: #{key}. #{INCOMPATIBLE_KEYS_WARNING}"
-      end
-
-      def extant_engines_or_languages_key
-        if self["engines"]
-          "engines"
-        elsif self["languages"]
-          "languages"
+          warning(INCOMPATIBLE_KEYS_WARNING, key)
         end
       end
 

--- a/spec/cc/yaml/nodes/engine_list_spec.rb
+++ b/spec/cc/yaml/nodes/engine_list_spec.rb
@@ -12,7 +12,7 @@ describe CC::Yaml::Nodes::EngineList do
   end
 
   specify "with languages already present, it throws a warning" do
-    config = CC::Yaml.parse! <<-YAML
+    config = CC::Yaml.parse <<-YAML
       languages:
         Ruby: true
         JavaScript: true

--- a/spec/cc/yaml/nodes/engine_list_spec.rb
+++ b/spec/cc/yaml/nodes/engine_list_spec.rb
@@ -20,11 +20,11 @@ describe CC::Yaml::Nodes::EngineList do
         rubocop:
           enabled: true
     YAML
-    config.warnings.must_include "languages key already found, dropping key: engines. Analysis settings for Languages and Engines are both valid but mutually exclusive. Note: command line analysis requires an Engines configuration."
+    config.warnings.must_include CC::Yaml::Nodes::Mapping::INCOMPATIBLE_KEYS_WARNING
   end
 
   specify "with languages already present, it drops engines key and keeps languages" do
-    config = CC::Yaml.parse! <<-YAML
+    config = CC::Yaml.parse <<-YAML
       languages:
         Ruby: true
         JavaScript: true

--- a/spec/cc/yaml/nodes/language_list_spec.rb
+++ b/spec/cc/yaml/nodes/language_list_spec.rb
@@ -2,7 +2,7 @@ require "spec_helper"
 
 describe CC::Yaml::Nodes::LanguageList do
   specify "with languages" do
-    config = CC::Yaml.parse! <<-YAML
+    config = CC::Yaml.parse <<-YAML
       languages:
         Ruby: true
         JavaScript: true
@@ -13,7 +13,7 @@ describe CC::Yaml::Nodes::LanguageList do
   end
 
   specify "with engines already present, it throws an incompatibility warning" do
-    config = CC::Yaml.parse! <<-YAML
+    config = CC::Yaml.parse <<-YAML
       engines:
         rubocop:
           enabled: true
@@ -22,11 +22,11 @@ describe CC::Yaml::Nodes::LanguageList do
         JavaScript: true
         Python: false
     YAML
-    config.warnings.must_include "engines key already found, dropping key: languages. Analysis settings for Languages and Engines are both valid but mutually exclusive. Note: command line analysis requires an Engines configuration."
+    config.warnings.must_include CC::Yaml::Nodes::Mapping::INCOMPATIBLE_KEYS_WARNING
   end
 
   specify "with engines already present, it leaves engines key and drops languages key" do
-    config = CC::Yaml.parse! <<-YAML
+    config = CC::Yaml.parse <<-YAML
       engines:
         rubocop:
           enabled: true

--- a/spec/cc/yaml/parser/psych_spec.rb
+++ b/spec/cc/yaml/parser/psych_spec.rb
@@ -1,0 +1,13 @@
+require "spec_helper"
+
+describe CC::Yaml::Parser::Psych do
+  specify "emits warning when no engines or languages key is found" do
+    yaml = <<-YAML
+    exclude_paths:
+      - "*.rb"
+      - "test/*"
+    YAML
+    config = CC::Yaml.parse yaml
+    config.warnings.must_include CC::Yaml::Parser::Psych::WARNING_NO_ANALYSIS_KEY_FOUND
+  end
+end

--- a/spec/cc/yaml_spec.rb
+++ b/spec/cc/yaml_spec.rb
@@ -1,12 +1,12 @@
-require 'spec_helper'
-require 'logger'
+require "spec_helper"
+require "logger"
 
 describe CC::Yaml do
   describe ".parse" do
     it "returns a node" do
-      config = CC::Yaml.parse('yargle: bargle')
+      config = CC::Yaml.parse("yargle: bargle")
       config.class.must_equal CC::Yaml::Nodes::Root
-      config.nested_warnings.must_equal [[[], 'unexpected key "yargle", dropping']]
+      config.nested_warnings.must_equal [[[], 'unexpected key "yargle", dropping'], [[], CC::Yaml::Parser::Psych::WARNING_NO_ANALYSIS_KEY_FOUND]]
     end
   end
 


### PR DESCRIPTION
@codeclimate/review @jonathancadepowers PR:

1) simplifies language in warning when both engines and languages keys are found.

for the following yaml

```yaml
---
engines:
  rubocop:
    enabled: true
languages:
  JavaScript: true
ratings:
  paths:
  - "**.rb"
exclude_paths:
- spec/**/*
```

previous warning (from current CLI): 
```
WARNING: engines key already found, dropping key: languages. Analysis settings for Languages and 
Engines are both valid but mutually exclusive. Note: command line analysis requires an Engines 
configuration.
```
new warning (from codeclimate-yaml): 
```
>> test = CC::Yaml.parse(File.read(".codeclimate.yml"))
=> #<CC::Yaml::Nodes::Root:{"engines"=>{"rubocop"=>{"enabled"=>true}}, "ratings"=>{"paths"=>"**.rb"}, "exclude_paths"=>"spec/**/*"}>
>> test.warnings
=> ["Use either a Languages key or an Engines key, but not both. They are mutually exclusive."]
>> 
```

2) Sets a warning if no `engines` or `languages` key is found. 

```console
>> test = CC::Yaml.parse(File.read(".codeclimate.yml"))
=> #<CC::Yaml::Nodes::Root:{"ratings"=>{"paths"=>"**.rb"}, "exclude_paths"=>"spec/**/*"}>
>> test.warnings
=> ["No languages or engines key found. Must have analysis key."]
>> 
```

I added a check for the presence of these to `psych.rb`, but am not sure if that's the best place for it to live. I had to update one old test to make work.