### PR TITLE
Engines and Lanugages warnings appear as errors

### DIFF
--- a/lib/cc/yaml/nodes/mapping.rb
+++ b/lib/cc/yaml/nodes/mapping.rb
@@ -1,7 +1,7 @@
 module CC::Yaml
   module Nodes
     class Mapping < Node
-      INCOMPATIBLE_KEYS_WARNING = "Use either a Languages key or an Engines key, but not both. They are mutually exclusive.".freeze
+      INCOMPATIBLE_KEYS_ERROR = "Use either a Languages key or an Engines key, but not both. They are mutually exclusive.".freeze
 
       def self.mapping
         @mapping ||= superclass.respond_to?(:mapping) ? superclass.mapping.dup : {}
@@ -187,7 +187,7 @@ module CC::Yaml
 
       def check_incompatibility(key)
         if creates_incompatibility?(key)
-          error INCOMPATIBLE_KEYS_WARNING
+          error INCOMPATIBLE_KEYS_ERROR
         end
       end
 

--- a/lib/cc/yaml/nodes/mapping.rb
+++ b/lib/cc/yaml/nodes/mapping.rb
@@ -187,7 +187,7 @@ module CC::Yaml
 
       def check_incompatibility(key)
         if creates_incompatibility?(key)
-          warning(INCOMPATIBLE_KEYS_WARNING, key)
+          error INCOMPATIBLE_KEYS_WARNING
         end
       end
 

--- a/lib/cc/yaml/parser/psych.rb
+++ b/lib/cc/yaml/parser/psych.rb
@@ -92,7 +92,7 @@ module CC::Yaml
 
       def check_for_analysis_key(root)
         unless root.engines? || root.languages?
-          root.warnings << WARNING_NO_ANALYSIS_KEY_FOUND
+          root.error WARNING_NO_ANALYSIS_KEY_FOUND
         end
       end
 

--- a/lib/cc/yaml/parser/psych.rb
+++ b/lib/cc/yaml/parser/psych.rb
@@ -4,7 +4,7 @@ require 'delegate'
 module CC::Yaml
   module Parser
     class Psych
-      WARNING_NO_ANALYSIS_KEY_FOUND = "No languages or engines key found. Must have analysis key.".freeze
+      NO_ANALYSIS_KEY_FOUND_ERROR = "No languages or engines key found. Must have analysis key.".freeze
 
       class SetNode < DelegateClass(::Psych::Nodes::Mapping)
         def children
@@ -92,7 +92,7 @@ module CC::Yaml
 
       def check_for_analysis_key(root)
         unless root.engines? || root.languages?
-          root.error WARNING_NO_ANALYSIS_KEY_FOUND
+          root.error NO_ANALYSIS_KEY_FOUND_ERROR
         end
       end
 

--- a/spec/cc/yaml/nodes/engine_list_spec.rb
+++ b/spec/cc/yaml/nodes/engine_list_spec.rb
@@ -20,7 +20,7 @@ describe CC::Yaml::Nodes::EngineList do
         rubocop:
           enabled: true
     YAML
-    config.errors.must_include CC::Yaml::Nodes::Mapping::INCOMPATIBLE_KEYS_WARNING
+    config.errors.must_include CC::Yaml::Nodes::Mapping::INCOMPATIBLE_KEYS_ERROR
   end
 
   specify "with languages already present, it drops engines key and keeps languages" do

--- a/spec/cc/yaml/nodes/engine_list_spec.rb
+++ b/spec/cc/yaml/nodes/engine_list_spec.rb
@@ -20,7 +20,7 @@ describe CC::Yaml::Nodes::EngineList do
         rubocop:
           enabled: true
     YAML
-    config.warnings.must_include CC::Yaml::Nodes::Mapping::INCOMPATIBLE_KEYS_WARNING
+    config.errors.must_include CC::Yaml::Nodes::Mapping::INCOMPATIBLE_KEYS_WARNING
   end
 
   specify "with languages already present, it drops engines key and keeps languages" do

--- a/spec/cc/yaml/nodes/language_list_spec.rb
+++ b/spec/cc/yaml/nodes/language_list_spec.rb
@@ -22,7 +22,7 @@ describe CC::Yaml::Nodes::LanguageList do
         JavaScript: true
         Python: false
     YAML
-    config.errors.must_include CC::Yaml::Nodes::Mapping::INCOMPATIBLE_KEYS_WARNING
+    config.errors.must_include CC::Yaml::Nodes::Mapping::INCOMPATIBLE_KEYS_ERROR
   end
 
   specify "with engines already present, it leaves engines key and drops languages key" do

--- a/spec/cc/yaml/nodes/language_list_spec.rb
+++ b/spec/cc/yaml/nodes/language_list_spec.rb
@@ -22,7 +22,7 @@ describe CC::Yaml::Nodes::LanguageList do
         JavaScript: true
         Python: false
     YAML
-    config.warnings.must_include CC::Yaml::Nodes::Mapping::INCOMPATIBLE_KEYS_WARNING
+    config.errors.must_include CC::Yaml::Nodes::Mapping::INCOMPATIBLE_KEYS_WARNING
   end
 
   specify "with engines already present, it leaves engines key and drops languages key" do

--- a/spec/cc/yaml/parser/psych_spec.rb
+++ b/spec/cc/yaml/parser/psych_spec.rb
@@ -8,6 +8,6 @@ describe CC::Yaml::Parser::Psych do
       - "test/*"
     YAML
     config = CC::Yaml.parse yaml
-    config.errors.must_include CC::Yaml::Parser::Psych::WARNING_NO_ANALYSIS_KEY_FOUND
+    config.errors.must_include CC::Yaml::Parser::Psych::NO_ANALYSIS_KEY_FOUND_ERROR
   end
 end

--- a/spec/cc/yaml/parser/psych_spec.rb
+++ b/spec/cc/yaml/parser/psych_spec.rb
@@ -8,6 +8,6 @@ describe CC::Yaml::Parser::Psych do
       - "test/*"
     YAML
     config = CC::Yaml.parse yaml
-    config.warnings.must_include CC::Yaml::Parser::Psych::WARNING_NO_ANALYSIS_KEY_FOUND
+    config.errors.must_include CC::Yaml::Parser::Psych::WARNING_NO_ANALYSIS_KEY_FOUND
   end
 end

--- a/spec/cc/yaml_spec.rb
+++ b/spec/cc/yaml_spec.rb
@@ -6,7 +6,7 @@ describe CC::Yaml do
     it "returns a node" do
       config = CC::Yaml.parse("yargle: bargle")
       config.class.must_equal CC::Yaml::Nodes::Root
-      config.nested_warnings.must_equal [[[], 'unexpected key "yargle", dropping'], [[], CC::Yaml::Parser::Psych::WARNING_NO_ANALYSIS_KEY_FOUND]]
+      config.nested_warnings.must_equal [[[], CC::Yaml::Parser::Psych::WARNING_NO_ANALYSIS_KEY_FOUND], [[], 'unexpected key "yargle", dropping']]
     end
 
     it "returns a node with errors" do

--- a/spec/cc/yaml_spec.rb
+++ b/spec/cc/yaml_spec.rb
@@ -6,7 +6,7 @@ describe CC::Yaml do
     it "returns a node" do
       config = CC::Yaml.parse("yargle: bargle")
       config.class.must_equal CC::Yaml::Nodes::Root
-      config.nested_warnings.must_equal [[[], CC::Yaml::Parser::Psych::WARNING_NO_ANALYSIS_KEY_FOUND], [[], 'unexpected key "yargle", dropping']]
+      config.nested_warnings.must_equal [[[], CC::Yaml::Parser::Psych::NO_ANALYSIS_KEY_FOUND_ERROR], [[], 'unexpected key "yargle", dropping']]
     end
 
     it "returns a node with errors" do


### PR DESCRIPTION
@codeclimate/review For review.

Currently, warnings will appear for analysis keys if a config:

1) has no `languages` or `engines` key
2) has BOTH keys (incompatible)

This PR changes those warnings into errors - (without raising an error). 

Main effect is that the root interface will tell other programs that these issues are errors (instead of warnings).

Not sure if it's a change we'd like. 