### PR TITLE
Remove custom JSON serialization

### DIFF
--- a/lib/cc/yaml/nodes/node.rb
+++ b/lib/cc/yaml/nodes/node.rb
@@ -97,8 +97,8 @@ module CC
           __getobj__.to_s
         end
 
-        def to_json(options = nil)
-          Serializer::Json.serialize(self, options)
+        def as_json(options = nil)
+          __getobj__.as_json(options)
         end
 
         def with_value(value)

--- a/spec/cc/yaml/nodes/engine_spec.rb
+++ b/spec/cc/yaml/nodes/engine_spec.rb
@@ -28,4 +28,15 @@ engines:
     engine = config.engines["rubocop"]
     engine.enabled?.must_equal false
   end
+
+  specify 'to_json' do
+    config = CC::Yaml.parse! <<-YAML
+engines:
+  rubocop:
+    enabled: true
+    YAML
+
+    json = config.engines.map { |_,v| v.to_json }.first
+    json.must_equal %{{"enabled":true}}
+  end
 end


### PR DESCRIPTION
- This appears to be used for masking Travis's "secure" values
- It raises various unexpected exceptions if you call to_json on a hash
  containing a node value, depending on what else is in the hash
- Delegating to the node's value's as_json implementation works and is simpler
  and not surprising

/cc @codeclimate/review