### PR TITLE
Yamelize value in `[]=` method on mapping

### DIFF
--- a/lib/cc/yaml.rb
+++ b/lib/cc/yaml.rb
@@ -1,3 +1,5 @@
+require "yaml"
+
 module CC
   module Yaml
     autoload :Nodes, "cc/yaml/nodes"
@@ -17,6 +19,10 @@ module CC
       end
 
       result
+    end
+
+    def self.dump(value)
+      YAML.dump(value)
     end
 
     def self.new

--- a/lib/cc/yaml/nodes/mapping.rb
+++ b/lib/cc/yaml/nodes/mapping.rb
@@ -77,12 +77,16 @@ module CC::Yaml
         if mapped_key = mapped_key(key)
           unless value.is_a? Node
             node  = subnode_for(mapped_key)
-            value = node if Parser::Ruby.new(value).parse(node)
+            value = node if Parser::Psych.new(yamelize(value)).parse(node)
           end
           @mapping[mapped_key] = value
         else
           warning("unexpected key %p, dropping", key)
         end
+      end
+
+      def yamelize(value)
+        CC::Yaml.dump(value)
       end
 
       def [](key)

--- a/lib/cc/yaml/nodes/node.rb
+++ b/lib/cc/yaml/nodes/node.rb
@@ -113,9 +113,9 @@ module CC
 
         protected
 
-          def dup_values
-            self
-          end
+        def dup_values
+          self
+        end
       end
     end
   end

--- a/lib/cc/yaml/nodes/sequence.rb
+++ b/lib/cc/yaml/nodes/sequence.rb
@@ -94,7 +94,7 @@ module CC::Yaml
         return value.dup if value.is_a? self.class
         value = value.children if value.is_a? Sequence
         value = value.value while value.is_a? Scalar
-        Parser::Ruby.new(Array(value)).parse self.class.new(parent)
+        Parser::Psych.new(Array(value)).parse self.class.new(parent)
       end
 
       def with_value!(value)

--- a/lib/cc/yaml/parser/psych.rb
+++ b/lib/cc/yaml/parser/psych.rb
@@ -81,13 +81,19 @@ module CC::Yaml
         parsed   = @value if @value.is_a? ::Psych::Nodes::Node
         parsed ||= ::Psych.parse(@value)
         accept(root, parsed)
-        check_for_analysis_key(root)
+        check_for_analysis_key_if_needed(root)
         root
       rescue ::Psych::SyntaxError => error
         root.verify
         root.warnings.clear
         root.error("syntax error: %s", error.message)
         root
+      end
+
+      def check_for_analysis_key_if_needed(root)
+        if root.respond_to? :engines?
+          check_for_analysis_key(root)
+        end
       end
 
       def check_for_analysis_key(root)

--- a/spec/cc/yaml/nodes/mapping_spec.rb
+++ b/spec/cc/yaml/nodes/mapping_spec.rb
@@ -1,0 +1,49 @@
+require "spec_helper"
+
+describe CC::Yaml::Nodes::Mapping do
+  describe "#[]" do
+    it "returns value in mapping" do
+      config = CC::Yaml.parse <<-YAML
+        languages:
+          Ruby: false
+          JavaScript: true
+          Python: true
+      YAML
+
+      config.languages["Ruby"].value.must_equal false
+    end
+  end
+
+  describe "#[]=" do
+    it "updates values in mapping" do
+      config = CC::Yaml.parse <<-YAML
+        languages:
+          Ruby: true
+          JavaScript: false
+          Python: false
+      YAML
+
+      config.languages.must_equal({ "Ruby" => true, "JavaScript" => false, "Python" => false })
+      config.languages["JavaScript"].value.must_equal false
+
+      config.languages["JavaScript"] = true
+
+      config.languages["JavaScript"].value.must_equal true
+      config.languages.must_equal({ "Ruby" => true, "JavaScript" => true, "Python" => false })
+    end
+
+    it "updates values in mapping" do
+      config = CC::Yaml.parse <<-YAML
+        languages:
+          Ruby: true
+          JavaScript: true
+          Python: false
+      YAML
+      config.languages.must_equal({ "Ruby" => true, "JavaScript" => true, "Python" => false })
+      config.languages["PHP"] = true
+
+      config.languages["PHP"].value.must_equal true
+      config.languages.must_equal({ "Ruby" => true, "JavaScript" => true, "Python" => false, "PHP" => true })
+    end
+  end
+end

--- a/spec/cc/yaml_spec.rb
+++ b/spec/cc/yaml_spec.rb
@@ -31,4 +31,13 @@ describe CC::Yaml do
       config.class.must_equal CC::Yaml::Nodes::Root
     end
   end
+
+  describe ".dump" do
+    it "returns a yamelized form of value" do
+      value = { "yargle" => true }
+      yamelized_value = CC::Yaml.dump(value)
+
+      yamelized_value.must_equal("---\nyargle: true\n")
+    end
+  end
 end


### PR DESCRIPTION
@codeclimate/review This PR fixes bug in value parsing in `[]=` method on `mapping` by:

1) making `engines?` and `languages?` check on root conditional
2) yamelizing value (in method) before it gets added

