### PR TITLE
Make engines and languages key a warning

### DIFF
--- a/lib/cc/yaml/nodes/mapping.rb
+++ b/lib/cc/yaml/nodes/mapping.rb
@@ -1,7 +1,7 @@
 module CC::Yaml
   module Nodes
     class Mapping < Node
-      INCOMPATIBLE_KEYS_ERROR = "Use either a Languages key or an Engines key, but not both. They are mutually exclusive.".freeze
+      INCOMPATIBLE_KEYS_WARNING = "Use either a Languages key or an Engines key, but not both. They are mutually exclusive.".freeze
 
       def self.mapping
         @mapping ||= superclass.respond_to?(:mapping) ? superclass.mapping.dup : {}
@@ -187,7 +187,7 @@ module CC::Yaml
 
       def check_incompatibility(key)
         if creates_incompatibility?(key)
-          error INCOMPATIBLE_KEYS_ERROR
+          warning INCOMPATIBLE_KEYS_WARNING
         end
       end
 

--- a/spec/cc/yaml/nodes/engine_list_spec.rb
+++ b/spec/cc/yaml/nodes/engine_list_spec.rb
@@ -20,7 +20,7 @@ describe CC::Yaml::Nodes::EngineList do
         rubocop:
           enabled: true
     YAML
-    config.errors.must_include CC::Yaml::Nodes::Mapping::INCOMPATIBLE_KEYS_ERROR
+    config.warnings.must_include CC::Yaml::Nodes::Mapping::INCOMPATIBLE_KEYS_WARNING
   end
 
   specify "with languages already present, it drops engines key and keeps languages" do

--- a/spec/cc/yaml/nodes/language_list_spec.rb
+++ b/spec/cc/yaml/nodes/language_list_spec.rb
@@ -22,7 +22,7 @@ describe CC::Yaml::Nodes::LanguageList do
         JavaScript: true
         Python: false
     YAML
-    config.errors.must_include CC::Yaml::Nodes::Mapping::INCOMPATIBLE_KEYS_ERROR
+    config.warnings.must_include CC::Yaml::Nodes::Mapping::INCOMPATIBLE_KEYS_WARNING
   end
 
   specify "with engines already present, it leaves engines key and drops languages key" do


### PR DESCRIPTION
This scenario does not itself prevent an analysis from succeeding. Making this
a warning not an error will allow analyses to proceed but still display a
notice on the analysis settings page and during validate-config.