### PR TITLE
Remove special node handling in assigment

### DIFF
--- a/lib/cc/yaml/nodes/mapping.rb
+++ b/lib/cc/yaml/nodes/mapping.rb
@@ -75,10 +75,6 @@ module CC::Yaml
 
       def []=(key, value)
         if mapped_key = mapped_key(key)
-          unless value.is_a? Node
-            node  = subnode_for(mapped_key)
-            value = node if Parser::Ruby.new(value).parse(node)
-          end
           @mapping[mapped_key] = value
         else
           warning("unexpected key %p, dropping", key)

--- a/spec/cc/yaml/nodes/engine_spec.rb
+++ b/spec/cc/yaml/nodes/engine_spec.rb
@@ -54,4 +54,31 @@ engines:
     check = checks["Style/StringLiteral"]
     check.enabled?.must_equal false
   end
+
+  specify 'assignment of raw value' do
+    config = CC::Yaml.parse! <<-YAML
+engines:
+  rubocop:
+    enabled: true
+    YAML
+
+    config.engines["rubocop"].enabled = false
+    config.engines["rubocop"].enabled?.must_equal false
+  end
+
+  specify 'assignment of subnode' do
+    config_1 = CC::Yaml.parse! <<-YAML
+engines:
+  rubocop:
+    enabled: true
+    YAML
+    config_2 = CC::Yaml.parse! <<-YAML
+engines:
+  eslint:
+    enabled: true
+    YAML
+
+    config_2.engines = config_1.engines
+    config_2.engines["rubocop"].enabled?.must_equal true
+  end
 end

--- a/spec/cc/yaml/nodes/engine_spec.rb
+++ b/spec/cc/yaml/nodes/engine_spec.rb
@@ -54,31 +54,4 @@ engines:
     check = checks["Style/StringLiteral"]
     check.enabled?.must_equal false
   end
-
-  specify 'assignment of raw value' do
-    config = CC::Yaml.parse! <<-YAML
-engines:
-  rubocop:
-    enabled: true
-    YAML
-
-    config.engines["rubocop"].enabled = false
-    config.engines["rubocop"].enabled?.must_equal false
-  end
-
-  specify 'assignment of subnode' do
-    config_1 = CC::Yaml.parse! <<-YAML
-engines:
-  rubocop:
-    enabled: true
-    YAML
-    config_2 = CC::Yaml.parse! <<-YAML
-engines:
-  eslint:
-    enabled: true
-    YAML
-
-    config_2.engines = config_1.engines
-    config_2.engines["rubocop"].enabled?.must_equal true
-  end
 end

--- a/spec/cc/yaml/nodes/mapping_spec.rb
+++ b/spec/cc/yaml/nodes/mapping_spec.rb
@@ -1,0 +1,27 @@
+require "spec_helper"
+
+module CC::Yaml::Nodes
+  describe Mapping do
+    def setup
+      Root.class_eval do
+        map :example, to: Scalar[:bool]
+      end
+    end
+
+    it "supports assignment of primitives" do
+      config = CC::Yaml.parse("example: true")
+
+      config.example = false
+      config.example.must_equal false
+    end
+
+    it "supports assignment of node objects" do
+      config_1 = CC::Yaml.parse("example: true")
+      config_2 = CC::Yaml.parse("example: false")
+
+      config_1.example = config_2.example
+      config_1.example.is_a?(Node).must_equal true
+      config_1.example.value.must_equal false
+    end
+  end
+end


### PR DESCRIPTION
AFAICT, this logic has two behaviors when the assigned value is not a node:

- Check if the value parses, perform this check with a class that doesn't exist
  -- blow up
- Don't even assign the value, always re-assign the existing node after this
  no-op parse-check

After adding a spec around assignments, the logic was removed. The rest of the
suite remains green at this time as well.

/cc @codeclimate/review

This would replace https://github.com/codeclimate/codeclimate-yaml/pull/15