### PR TITLE
don't drop analysis key when warning about incompatibility

### DIFF
--- a/lib/cc/yaml/nodes/mapping.rb
+++ b/lib/cc/yaml/nodes/mapping.rb
@@ -54,6 +54,7 @@ module CC::Yaml
       def visit_pair(visitor, key, value)
         key = visitor.generate_key(self, key)
         unless set_warnings(key)
+          check_incompatibility(key)
           visit_key_value(visitor, key, value)
         end
       end
@@ -67,7 +68,6 @@ module CC::Yaml
       def set_warnings(key)
         if subnode_for(key)
           check_duplicates(key)
-          check_incompatibility(key)
         else
           warning("unexpected key %p, dropping", key)
         end

--- a/spec/cc/yaml/nodes/engine_list_spec.rb
+++ b/spec/cc/yaml/nodes/engine_list_spec.rb
@@ -32,7 +32,7 @@ describe CC::Yaml::Nodes::EngineList do
         rubocop:
           enabled: true
     YAML
-    config.engines.must_equal({ "rubocop" => { "enabled" => true } })
-    config.languages.must_equal({ "Ruby" => true, "JavaScript" => true })
+    config.engines.must_equal("rubocop" => { "enabled" => true })
+    config.languages.must_equal("Ruby" => true, "JavaScript" => true)
   end
 end

--- a/spec/cc/yaml/nodes/engine_list_spec.rb
+++ b/spec/cc/yaml/nodes/engine_list_spec.rb
@@ -23,7 +23,7 @@ describe CC::Yaml::Nodes::EngineList do
     config.warnings.must_include CC::Yaml::Nodes::Mapping::INCOMPATIBLE_KEYS_WARNING
   end
 
-  specify "with languages already present, it drops engines key and keeps languages" do
+  specify "with languages already present, it keeps both engines and languages keys" do
     config = CC::Yaml.parse <<-YAML
       languages:
         Ruby: true
@@ -32,7 +32,7 @@ describe CC::Yaml::Nodes::EngineList do
         rubocop:
           enabled: true
     YAML
-    config.engines.must_equal nil
+    config.engines.must_equal({ "rubocop" => { "enabled" => true } })
     config.languages.must_equal({ "Ruby" => true, "JavaScript" => true })
   end
 end

--- a/spec/cc/yaml/nodes/language_list_spec.rb
+++ b/spec/cc/yaml/nodes/language_list_spec.rb
@@ -9,7 +9,7 @@ describe CC::Yaml::Nodes::LanguageList do
         Python: false
     YAML
     config.languages.size.must_equal 3
-    config.languages.must_equal({ "Ruby" => true, "JavaScript" => true, "Python" => false })
+    config.languages.must_equal("Ruby" => true, "JavaScript" => true, "Python" => false)
   end
 
   specify "with engines already present, it throws an incompatibility warning" do
@@ -36,6 +36,6 @@ describe CC::Yaml::Nodes::LanguageList do
         Python: false
     YAML
     config.engines.keys.must_equal ["rubocop"]
-    config.languages.must_equal({ "Ruby" => true, "JavaScript" => true, "Python" => false })
+    config.languages.must_equal("Ruby" => true, "JavaScript" => true, "Python" => false)
   end
 end

--- a/spec/cc/yaml/nodes/language_list_spec.rb
+++ b/spec/cc/yaml/nodes/language_list_spec.rb
@@ -25,7 +25,7 @@ describe CC::Yaml::Nodes::LanguageList do
     config.warnings.must_include CC::Yaml::Nodes::Mapping::INCOMPATIBLE_KEYS_WARNING
   end
 
-  specify "with engines already present, it leaves engines key and drops languages key" do
+  specify "with engines already present, it keeps both engines and languages keys" do
     config = CC::Yaml.parse <<-YAML
       engines:
         rubocop:
@@ -36,6 +36,6 @@ describe CC::Yaml::Nodes::LanguageList do
         Python: false
     YAML
     config.engines.keys.must_equal ["rubocop"]
-    config.languages.must_equal nil
+    config.languages.must_equal({ "Ruby" => true, "JavaScript" => true, "Python" => false })
   end
 end


### PR DESCRIPTION
@codeclimate/review @pbrisbin 

Previously, when we add a `warning` for a `node` in the `mapping` class, that node is dropped.

This PR makes it so that in the case of incompatible analysis keys, a `warning` is added, but the key is not dropped.

e.g. with `.codeclimate.yml` file:
```YAML
---
engines:
  rubocop:
    enabled: true
languages:
  Ruby: true
ratings:
  paths:
  - "**.rb"
exclude_paths:
- spec/**/*
```

```console
test = CC::Yaml.parse(File.read(".codeclimate.yml"))
#<CC::Yaml::Nodes::Root:{"engines"=>{"rubocop"=>{"enabled"=>true}}, "ratings"=>{"paths"=>"**/*.rb"}, "exclude_paths"=>"spec/**/*"}>

test.warnings
=> ["Use either a Languages key or an Engines key, but not both. They are mutually exclusive."]
 
```

