### PR TITLE
Add failing spec

### DIFF
--- a/lib/cc/yaml/nodes.rb
+++ b/lib/cc/yaml/nodes.rb
@@ -4,7 +4,6 @@ module CC
       autoload :Check, "cc/yaml/nodes/check"
       autoload :Checks, "cc/yaml/nodes/checks"
       autoload :Engine, "cc/yaml/nodes/engine"
-      autoload :EngineConfig, "cc/yaml/nodes/engine_config"
       autoload :EngineList, "cc/yaml/nodes/engine_list"
       autoload :Glob, "cc/yaml/nodes/glob"
       autoload :GlobList, "cc/yaml/nodes/glob_list"

--- a/lib/cc/yaml/nodes/engine.rb
+++ b/lib/cc/yaml/nodes/engine.rb
@@ -4,7 +4,28 @@ module CC
       class Engine < Mapping
         map :enabled, to: Scalar[:bool], required: true
         map :checks, to: Checks
-        map :config, to: EngineConfig
+        map :config, to: Mapping
+
+        attr_reader :config
+
+        def visit_key_value(visitor, key, value)
+          if key == "config"
+            raw_value = value.to_ruby
+
+            # backwards compatability for phpcodesniffer
+            if raw_value.is_a?(String)
+              @config = { "file" => raw_value }
+            else
+              @config = raw_value
+            end
+          else
+            super
+          end
+        end
+
+        def reload
+          self.merge!("config" => @config)
+        end
       end
     end
   end

--- a/lib/cc/yaml/nodes/engine_config.rb
+++ b/lib/cc/yaml/nodes/engine_config.rb
@@ -1,9 +1,0 @@
-module CC
-  module Yaml
-    module Nodes
-      class EngineConfig < OpenMapping
-        prefix_scalar :file
-      end
-    end
-  end
-end

--- a/spec/cc/yaml/nodes/engine_spec.rb
+++ b/spec/cc/yaml/nodes/engine_spec.rb
@@ -79,4 +79,29 @@ engines:
     config = yaml.engines["phpcodesniffer"].config
     config.must_equal("file" => "config.php")
   end
+
+  specify "arbitrary config values" do
+    yaml = CC::Yaml.parse <<-YAML
+engines:
+  phpcodesniffer:
+    enabled: true
+    config:
+      x: "y"
+      z:
+        a: "b"
+        c:
+          x: [1, 2, 3]
+          y:
+          - 4
+          - 5
+          - 6
+    YAML
+
+    config = yaml.engines["phpcodesniffer"].config
+
+    config["x"].must_equal "y"
+    config["z"]["a"].must_equal "b"
+    config["z"]["c"]["x"].must_equal [1, 2, 3]
+    config["z"]["c"]["y"].must_equal [4, 5, 6]
+  end
 end

--- a/spec/cc/yaml/parser/psych_spec.rb
+++ b/spec/cc/yaml/parser/psych_spec.rb
@@ -7,7 +7,47 @@ describe CC::Yaml::Parser::Psych do
       - "*.rb"
       - "test/*"
     YAML
+
     config = CC::Yaml.parse yaml
     config.errors.must_include CC::Yaml::Parser::Psych::NO_ANALYSIS_KEY_FOUND_ERROR
+  end
+
+  specify "properly parses engine data" do
+    yaml = <<-YAML
+    ---
+    engines:
+      duplication:
+        enabled: true
+        config:
+          ruby:
+            mass_threshold: 10
+          javascript:
+            mass_threshold: 20
+    YAML
+
+    parsed_yaml = CC::Yaml.parse yaml
+    config = parsed_yaml["engines"]["duplication"]["config"]
+
+    assert config.empty?, false
+    assert_equal config["ruby"]["mass_threshold"], 10
+    assert_equal config["javascript"]["mass_threshold"], 20
+  end
+
+  specify "supports listed values" do
+    yaml = <<-YAML
+    ---
+    engines:
+      duplication:
+        enabled: true
+        languages:
+          - "ruby"
+          - "javascript"
+    YAML
+
+    parsed_yaml = CC::Yaml.parse yaml
+    enabled_languages = parsed_yaml["engines"]["duplication"]["languages"]
+
+    assert enabled_languages.nil? false
+    assert_equal enabled_languages, ["ruby", "javascript"]
   end
 end

--- a/spec/cc/yaml/parser/psych_spec.rb
+++ b/spec/cc/yaml/parser/psych_spec.rb
@@ -14,7 +14,6 @@ describe CC::Yaml::Parser::Psych do
 
   specify "properly parses engine data" do
     yaml = <<-YAML
-    ---
     engines:
       duplication:
         enabled: true
@@ -26,28 +25,28 @@ describe CC::Yaml::Parser::Psych do
     YAML
 
     parsed_yaml = CC::Yaml.parse yaml
-    config = parsed_yaml["engines"]["duplication"]["config"]
+    config = parsed_yaml["engines"]["duplication"].config
 
-    assert config.empty?, false
+    assert !config.empty?
     assert_equal config["ruby"]["mass_threshold"], 10
     assert_equal config["javascript"]["mass_threshold"], 20
   end
 
   specify "supports listed values" do
     yaml = <<-YAML
-    ---
     engines:
       duplication:
         enabled: true
-        languages:
-          - "ruby"
-          - "javascript"
+        config:
+          languages:
+          - ruby
+          - javascript
     YAML
 
     parsed_yaml = CC::Yaml.parse yaml
-    enabled_languages = parsed_yaml["engines"]["duplication"]["languages"]
+    config = parsed_yaml["engines"]["duplication"].config
 
-    assert enabled_languages.nil? false
-    assert_equal enabled_languages, ["ruby", "javascript"]
+    assert !config['languages'].nil?
+    assert_equal config['languages'], ["ruby", "javascript"]
   end
 end

--- a/spec/cc/yaml/parser/psych_spec.rb
+++ b/spec/cc/yaml/parser/psych_spec.rb
@@ -25,7 +25,7 @@ describe CC::Yaml::Parser::Psych do
     YAML
 
     parsed_yaml = CC::Yaml.parse yaml
-    config = parsed_yaml["engines"]["duplication"].config
+    config = parsed_yaml.engines["duplication"].config
 
     assert !config.empty?
     assert_equal config["ruby"]["mass_threshold"], 10
@@ -44,9 +44,9 @@ describe CC::Yaml::Parser::Psych do
     YAML
 
     parsed_yaml = CC::Yaml.parse yaml
-    config = parsed_yaml["engines"]["duplication"].config
+    config = parsed_yaml.engines["duplication"].config
 
-    assert !config['languages'].nil?
-    assert_equal config['languages'], ["ruby", "javascript"]
+    assert !config["languages"].nil?
+    assert_equal config["languages"], ["ruby", "javascript"]
   end
 end


### PR DESCRIPTION
In order to enable configurable thresholds and multi language duplication analysis in the duplication engine you need to pass those options to .codeclimate.yml. Unfortunately they seem to get filtered out during the parsing.