### PR TITLE
Provide easy interface for adding engines to engine list

### DIFF
--- a/lib/cc/yaml/nodes/engine_list.rb
+++ b/lib/cc/yaml/nodes/engine_list.rb
@@ -3,6 +3,10 @@ module CC
     module Nodes
       class EngineList < OpenMapping
         default_type Engine
+
+        def add(engine_name, value)
+          self[engine_name] = Engine.new(self).with_value(value)
+        end
       end
     end
   end


### PR DESCRIPTION
This change will help make it easier to manipulate the config on the fly, as might be useful
in CLI analyze command when passed command line args of file paths
e.g. this change:
https://github.com/codeclimate/codeclimate/pull/113/files#diff-3704efb1e138ce39b40b57310885b140R67

@codeclimate/review 

Note: 
1) this method ATM will overwrite other engines in your parsed yaml root object if you 'add' one that's already present. 
2) I could explore using the `visit_mapping` methods on `node` or `mapping` and try to use those instead if that seems worthwhile? But it seems a little trickier
3) I could add a test for this functionality - working on ATM

edit: 4) we don't need an `add` method on `EngineList` to achieve this effect, but it seems like it gives a nice interface.