### PR TITLE
Add Rake as a required gem in the test environment

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,6 +3,7 @@ source 'https://rubygems.org'
 gemspec
 
 group :test do
+  gem "rake"
   gem "pry"
   gem "minitest"
   gem "minitest-reporters"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -30,6 +30,7 @@ GEM
       coderay (~> 1.1.0)
       method_source (~> 0.8.1)
       slop (~> 3.4)
+    rake (10.4.2)
     ruby-progressbar (1.7.5)
     secure_string (1.3.3)
     slop (3.6.0)
@@ -45,6 +46,7 @@ DEPENDENCIES
   minitest
   minitest-reporters
   pry
+  rake
 
 BUNDLED WITH
-   1.10.3
+   1.10.5


### PR DESCRIPTION
Just in case it isn't "globally" installed on a system already, preventing us
from running tests.