### PR TITLE
Allow engine config to have arbitrary mappings and depths

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,6 +3,7 @@ source 'https://rubygems.org'
 gemspec
 
 group :test do
+  gem "m"
   gem "rake"
   gem "pry"
   gem "minitest"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -19,6 +19,9 @@ GEM
     coderay (1.1.0)
     i18n (0.7.0)
     json (1.8.3)
+    m (1.4.0)
+      method_source (>= 0.6.7)
+      rake (>= 0.9.2.2)
     method_source (0.8.2)
     minitest (5.6.1)
     minitest-reporters (1.0.16)
@@ -43,6 +46,7 @@ PLATFORMS
 
 DEPENDENCIES
   codeclimate-yaml!
+  m
   minitest
   minitest-reporters
   pry

--- a/lib/cc/yaml/nodes.rb
+++ b/lib/cc/yaml/nodes.rb
@@ -10,6 +10,7 @@ module CC
       autoload :GlobList, "cc/yaml/nodes/glob_list"
       autoload :LanguageList, "cc/yaml/nodes/language_list"
       autoload :Mapping, "cc/yaml/nodes/mapping"
+      autoload :NestedConfig, "cc/yaml/nodes/nested_config"
       autoload :Node, "cc/yaml/nodes/node"
       autoload :OpenMapping, "cc/yaml/nodes/open_mapping"
       autoload :Ratings, "cc/yaml/nodes/ratings"

--- a/lib/cc/yaml/nodes/engine_config.rb
+++ b/lib/cc/yaml/nodes/engine_config.rb
@@ -1,7 +1,7 @@
 module CC
   module Yaml
     module Nodes
-      class EngineConfig < OpenMapping
+      class EngineConfig < NestedConfig
         prefix_scalar :file
       end
     end

--- a/lib/cc/yaml/nodes/nested_config.rb
+++ b/lib/cc/yaml/nodes/nested_config.rb
@@ -1,0 +1,24 @@
+module CC
+  module Yaml
+    module Nodes
+      class NestedConfig < OpenMapping
+        def visit_key_value(visitor, key, value)
+          node = subnode_for_pair(key, value)
+          assign_node_and_visit(node, key, value, visitor)
+        end
+
+        protected
+
+        def subnode_for_pair(key, value)
+          if value.is_a?(::Psych::Nodes::Mapping)
+            NestedConfig.new(self)
+          elsif value.is_a?(::Psych::Nodes::Sequence)
+            Sequence.new(self)
+          else
+            subnode_for_key(key)
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/cc/yaml/nodes/open_mapping.rb
+++ b/lib/cc/yaml/nodes/open_mapping.rb
@@ -6,7 +6,7 @@ module CC::Yaml
         @default_type ||= superclass.respond_to?(:default_type) ? superclass.default_type : Scalar
       end
 
-      def self.subnode_for(key)
+      def self.subnode_for_key(key)
         super(key) || default_type
       end
 

--- a/spec/cc/yaml/nodes/engine_config_spec.rb
+++ b/spec/cc/yaml/nodes/engine_config_spec.rb
@@ -1,0 +1,40 @@
+require "spec_helper"
+
+describe CC::Yaml::Nodes::EngineConfig do
+  specify "parses the engine config with arbitrary keys and depths" do
+    parsed_yaml = CC::Yaml.parse <<-YAML
+    engines:
+      duplication:
+        enabled: true
+        config:
+          languages:
+          - ruby
+          - python
+          a: "1"
+          b:
+            c:
+              d: "2"
+              e:
+              - items
+              - more items
+              f:
+                g: "last thing"
+                h:
+                  i: "whatever"
+    YAML
+
+    parsed_config = parsed_yaml.engines["duplication"].config
+    expected_config = {
+      "languages" => ["ruby", "python"],
+      "a" => "1",
+      "b" => {
+        "c" => {
+          "d" => "2",
+          "e" => ["items", "more items"],
+          "f" => { "g" => "last thing", "h" => { "i" => "whatever" } },
+        }
+      },
+    }
+    parsed_config.must_equal(expected_config)
+  end
+end


### PR DESCRIPTION
Previously, we've been explicitly mapping certain keys to certain types of
   nodes. However, we now need the ability to parse arbitrary configurations
   under the engine's `config` key, and the configurations could have
   arbitrary depths.

   To do this, we must explicitly check the type of the values that are in the
   configurations and map them to their appropriate node types. We're also
   introducing `ArbitraryConfig` so that we can support this recursive
   behavior.

   Also, as a separate commit: Add "m" gem to allow testing by line number

   @codeclimate/review