### PR TITLE
error improvements

### DIFF
--- a/lib/cc/yaml/nodes/engine_list.rb
+++ b/lib/cc/yaml/nodes/engine_list.rb
@@ -3,16 +3,28 @@ module CC
     module Nodes
       class EngineList < OpenMapping
         GENERIC_ERROR_MESSAGE = "The engines key should be a mapping from engine name to engine config.".freeze
+        EMPTY_ERROR_MESSAGE = "The engines key cannot be empty.".freeze
 
         default_type Engine
 
+        def verify
+          super
+          verify_not_empty
+        end
+
         def visit_unexpected(_visitor, _value, message = nil)
           if message
-            message = "#{message}. #{ERROR_MESSAGE}"
+            message = message << ". #{GENERIC_ERROR_MESSAGE}"
           else
-            message = ERROR_MESSAGE
+            message = GENERIC_ERROR_MESSAGE
           end
           error(message)
+        end
+
+        private
+
+        def verify_not_empty
+          error(EMPTY_ERROR_MESSAGE) if mapping.keys.empty? && errors.empty?
         end
       end
     end

--- a/lib/cc/yaml/nodes/engine_list.rb
+++ b/lib/cc/yaml/nodes/engine_list.rb
@@ -2,12 +2,17 @@ module CC
   module Yaml
     module Nodes
       class EngineList < OpenMapping
-        ERROR_MESSAGE="foo"
+        GENERIC_ERROR_MESSAGE = "The engines key should be a mapping from engine name to engine config.".freeze
 
         default_type Engine
 
-        def visit_unexpected(visitor, value, message = nil)
-          error(ERROR_MESSAGE)
+        def visit_unexpected(_visitor, _value, message = nil)
+          if message
+            message = "#{message}. #{ERROR_MESSAGE}"
+          else
+            message = ERROR_MESSAGE
+          end
+          error(message)
         end
       end
     end

--- a/lib/cc/yaml/nodes/engine_list.rb
+++ b/lib/cc/yaml/nodes/engine_list.rb
@@ -2,7 +2,13 @@ module CC
   module Yaml
     module Nodes
       class EngineList < OpenMapping
+        ERROR_MESSAGE="foo"
+
         default_type Engine
+
+        def visit_unexpected(visitor, value, message = nil)
+          error(ERROR_MESSAGE)
+        end
       end
     end
   end

--- a/lib/cc/yaml/nodes/mapping.rb
+++ b/lib/cc/yaml/nodes/mapping.rb
@@ -153,7 +153,7 @@ module CC::Yaml
       def verify_errors
         @mapping.delete_if do |key, value|
           if value.errors?
-            warning "dropping %p section: %s", key, value.errors.join(", ")
+            error "invalid %p section: %s", key, value.errors.join(", ")
             true
           end
         end

--- a/lib/cc/yaml/nodes/mapping.rb
+++ b/lib/cc/yaml/nodes/mapping.rb
@@ -1,7 +1,7 @@
 module CC::Yaml
   module Nodes
     class Mapping < Node
-      INCOMPATIBLE_KEYS_WARNING = "Use either a Languages key or an Engines key, but not both. They are mutually exclusive.".freeze
+      INCOMPATIBLE_KEYS_WARNING = "Use either a languages key or an engines key, but not both. They are mutually exclusive.".freeze
 
       def self.mapping
         @mapping ||= superclass.respond_to?(:mapping) ? superclass.mapping.dup : {}

--- a/lib/cc/yaml/nodes/node.rb
+++ b/lib/cc/yaml/nodes/node.rb
@@ -65,23 +65,23 @@ module CC
         end
 
         def visit_mapping(visitor, value)
-          error("unexpected mapping")
+          visit_unexpected(visitor, value, "unexpected mapping")
         end
 
         def visit_pair(visitor, key, value)
-          error("unexpected pair")
+          visit_unexpected(visitor, value, "unexpected pair")
         end
 
         def visit_scalar(visitor, type, value, implicit = true)
-          error("unexpected scalar") unless type == :null
+          visit_unexpected(visitor, value, "unexpected scalar") unless type == :null
         end
 
         def visit_sequence(visitor, value)
-          error("unexpected sequence")
+          visit_unexpected(visitor, value, "unexpected sequence")
         end
 
         def visit_child(visitor, value)
-          error("unexpected child")
+          visit_unexpected(visitor, value, "unexpected child")
         end
 
         def respond_to_missing?(method, include_private = false)

--- a/lib/cc/yaml/nodes/root.rb
+++ b/lib/cc/yaml/nodes/root.rb
@@ -10,8 +10,12 @@ module CC
         map :languages, to: LanguageList
         map :ratings, to: Ratings
 
+        attr_accessor :parseable
+        alias_method :parseable?, :parseable
+
         def initialize
           super(nil)
+          @parseable = true
         end
 
         def nested_warnings(*)

--- a/lib/cc/yaml/parser/psych.rb
+++ b/lib/cc/yaml/parser/psych.rb
@@ -91,7 +91,7 @@ module CC::Yaml
       end
 
       def check_for_analysis_key(root)
-        unless root.engines? || root.languages?
+        unless root.engines? || root.languages? || root.errors.any?
           root.error NO_ANALYSIS_KEY_FOUND_ERROR
         end
       end

--- a/lib/cc/yaml/parser/psych.rb
+++ b/lib/cc/yaml/parser/psych.rb
@@ -87,6 +87,7 @@ module CC::Yaml
         root.verify
         root.warnings.clear
         root.error("syntax error: %s", error.message)
+        root.parseable = false
         root
       end
 

--- a/spec/cc/yaml/nodes/engine_list_spec.rb
+++ b/spec/cc/yaml/nodes/engine_list_spec.rb
@@ -35,4 +35,15 @@ describe CC::Yaml::Nodes::EngineList do
     config.engines.must_equal("rubocop" => { "enabled" => true })
     config.languages.must_equal("Ruby" => true, "JavaScript" => true)
   end
+
+  specify "with invalid data, emits an error error" do
+    config = CC::Yaml.parse <<-YAML
+    engines:
+      - "not_an_engine"
+    exclude_paths:
+      - "*.rb"
+      - "test/*"
+    YAML
+    config.errors.must_include "invalid \"engines\" section: unexpected sequence. #{CC::Yaml::Nodes::EngineList::ERROR_MESSAGE}"
+  end
 end

--- a/spec/cc/yaml/nodes/engine_list_spec.rb
+++ b/spec/cc/yaml/nodes/engine_list_spec.rb
@@ -36,7 +36,7 @@ describe CC::Yaml::Nodes::EngineList do
     config.languages.must_equal("Ruby" => true, "JavaScript" => true)
   end
 
-  specify "with invalid data, emits an error error" do
+  specify "with invalid data, emits an error" do
     config = CC::Yaml.parse <<-YAML
     engines:
       - "not_an_engine"
@@ -44,6 +44,16 @@ describe CC::Yaml::Nodes::EngineList do
       - "*.rb"
       - "test/*"
     YAML
-    config.errors.must_include "invalid \"engines\" section: unexpected sequence. #{CC::Yaml::Nodes::EngineList::ERROR_MESSAGE}"
+    config.errors.must_include "invalid \"engines\" section: unexpected sequence. #{CC::Yaml::Nodes::EngineList::GENERIC_ERROR_MESSAGE}"
+  end
+
+  specify "with empty, emits an error" do
+    config = CC::Yaml.parse <<-YAML
+    engines:
+    exclude_paths:
+      - "*.rb"
+      - "test/*"
+    YAML
+    config.errors.must_include "invalid \"engines\" section: #{CC::Yaml::Nodes::EngineList::EMPTY_ERROR_MESSAGE}"
   end
 end

--- a/spec/cc/yaml/nodes/engine_spec.rb
+++ b/spec/cc/yaml/nodes/engine_spec.rb
@@ -1,14 +1,6 @@
 require 'spec_helper'
 
 describe CC::Yaml::Nodes::Engine do
-  specify 'default enabled' do
-    config = CC::Yaml.parse <<-YAML
-engines:
-  rubocop:
-    YAML
-    config.engines.warnings.must_equal ['dropping "rubocop" section: missing key "enabled"']
-  end
-
   specify 'enabled' do
     config = CC::Yaml.parse! <<-YAML
 engines:

--- a/spec/cc/yaml/parser/psych_spec.rb
+++ b/spec/cc/yaml/parser/psych_spec.rb
@@ -1,7 +1,7 @@
 require "spec_helper"
 
 describe CC::Yaml::Parser::Psych do
-  specify "emits warning when no engines or languages key is found" do
+  specify "emits error when no engines or languages key is found" do
     yaml = <<-YAML
     exclude_paths:
       - "*.rb"
@@ -9,5 +9,30 @@ describe CC::Yaml::Parser::Psych do
     YAML
     config = CC::Yaml.parse yaml
     config.errors.must_include CC::Yaml::Parser::Psych::NO_ANALYSIS_KEY_FOUND_ERROR
+  end
+
+  specify "does not emit no-key error if other errors occurred" do
+    yaml = <<-YAML
+    engines:
+    exclude_paths:
+      - "*.rb"
+      - "test/*"
+    YAML
+    config = CC::Yaml.parse yaml
+    config.errors.count.must_be :>, 0
+    config.errors.wont_include CC::Yaml::Parser::Psych::NO_ANALYSIS_KEY_FOUND_ERROR
+  end
+
+  specify "does not emit any errors for valid input" do
+    yaml = <<-YAML
+    engines:
+      rubocop:
+        enabled: true
+    exclude_paths:
+      - "*.rb"
+      - "test/*"
+    YAML
+    config = CC::Yaml.parse yaml
+    config.errors.count.must_equal 0
   end
 end

--- a/spec/cc/yaml_spec.rb
+++ b/spec/cc/yaml_spec.rb
@@ -13,6 +13,7 @@ describe CC::Yaml do
       config = CC::Yaml.parse("yargle: poskgp;aerwet ;rgr:  ")
       config.class.must_equal CC::Yaml::Nodes::Root
       config.errors.must_equal ["syntax error: (<unknown>): mapping values are not allowed in this context at line 1 column 27"]
+      config.parseable?.must_equal false
     end
   end
 


### PR DESCRIPTION
This improves what config validation will catch.

* Errors in child nodes should not, as a rule, be treated as warnings higher up the chain. Errors are errors.
* Send "unexpected type" errors through one place so we can more easily provide some custom error messages
* Flag an empty errors key as an error
* Don't report "no engines key" error in addition to more specific errors about the engines key existing but begin invalid.
* Make it possible for client code to distinguish between parse errors & other errors.

:eyeglasses: @codeclimate/review 