### PR TITLE
Allow engines to specify ignored_issues key

### DIFF
--- a/lib/cc/yaml/nodes/engine.rb
+++ b/lib/cc/yaml/nodes/engine.rb
@@ -5,6 +5,7 @@ module CC
         map :enabled, to: Scalar[:bool], required: true
         map :checks, to: Checks
         map :config, to: EngineConfig
+        map :ignored_issues, to: Sequence
       end
     end
   end

--- a/spec/cc/yaml/nodes/engine_spec.rb
+++ b/spec/cc/yaml/nodes/engine_spec.rb
@@ -71,4 +71,21 @@ engines:
     config = yaml.engines["phpcodesniffer"].config
     config.must_equal("file" => "config.php")
   end
+
+  specify "ignored_issues" do
+    yaml = CC::Yaml.parse! <<-YAML
+engines:
+  rubocop:
+    enabled: true
+    ignored_issues:
+      - be121740bf988b2225a313fa1f107ca1
+      - 1ffc9f9cc376341aa08bb5973c511ac3
+    YAML
+
+    config = yaml.engines["rubocop"].ignored_issues
+    config.must_equal([
+      "be121740bf988b2225a313fa1f107ca1",
+      "1ffc9f9cc376341aa08bb5973c511ac3"
+    ])
+  end
 end


### PR DESCRIPTION
This allows engines to have an `ignored_issues` key which takes an
array of fingerprint values that will be filtered by the `codeclimate`
executable and the application.