### PR TITLE
Rename ignored_issues to exclude_fingerprints

### DIFF
--- a/lib/cc/yaml/nodes/engine.rb
+++ b/lib/cc/yaml/nodes/engine.rb
@@ -5,7 +5,7 @@ module CC
         map :enabled, to: Scalar[:bool], required: true
         map :checks, to: Checks
         map :config, to: EngineConfig
-        map :ignored_issues, to: Sequence
+        map :exclude_fingerprints, to: Sequence
       end
     end
   end

--- a/spec/cc/yaml/nodes/engine_spec.rb
+++ b/spec/cc/yaml/nodes/engine_spec.rb
@@ -77,12 +77,12 @@ engines:
 engines:
   rubocop:
     enabled: true
-    ignored_issues:
+    exclude_fingerprints:
       - be121740bf988b2225a313fa1f107ca1
       - 1ffc9f9cc376341aa08bb5973c511ac3
     YAML
 
-    config = yaml.engines["rubocop"].ignored_issues
+    config = yaml.engines["rubocop"].exclude_fingerprints
     config.must_equal([
       "be121740bf988b2225a313fa1f107ca1",
       "1ffc9f9cc376341aa08bb5973c511ac3"


### PR DESCRIPTION
This renames `ignored_issues` to match the current convention of
`exclude_*`.