### PR TITLE
Add engine specific `exclude_paths`

### DIFF
--- a/lib/cc/yaml/nodes/engine.rb
+++ b/lib/cc/yaml/nodes/engine.rb
@@ -6,6 +6,7 @@ module CC
         map :checks, to: Checks
         map :config, to: EngineConfig
         map :exclude_fingerprints, to: Sequence
+        map :exclude_paths, to: GlobList
       end
     end
   end

--- a/spec/cc/yaml/nodes/engine_spec.rb
+++ b/spec/cc/yaml/nodes/engine_spec.rb
@@ -88,4 +88,21 @@ engines:
       "1ffc9f9cc376341aa08bb5973c511ac3"
     ])
   end
+
+  specify "exclude_paths" do
+    yaml = CC::Yaml.parse! <<-YAML
+engines:
+  rubocop:
+    enabled: true
+    exclude_paths:
+      - "**/*.rs"
+      - "**/*.ex"
+    YAML
+
+    config = yaml.engines["rubocop"].exclude_paths
+    config.must_equal([
+      "**/*.rs",
+      "**/*.ex"
+    ])
+  end
 end


### PR DESCRIPTION
This allows engine to have an `exclude_paths` key which will be used to exclude globs on a per-engine basis.