### PR TITLE
Alias glob#to_s to glob#value

### DIFF
--- a/lib/cc/yaml/nodes/glob.rb
+++ b/lib/cc/yaml/nodes/glob.rb
@@ -2,6 +2,10 @@ module CC
   module Yaml
     module Nodes
       class Glob < Scalar
+        def to_s
+          value
+        end
+
         def value
           @value.sub(%r{\*\*([^\/]*)?$}, "**/*\\1") # normalize glob format: app/** => app/**/* and **.rb => **/*.rb
         end


### PR DESCRIPTION
`#to_s` is the defacto Ruby way of getting the stringy value of things,
and we're currently depending on that in the CLI. In the case of legacy
globs like "**.rb", without this change calling `#to_s` would just give
you "**.rb" right back, which isn't desired and won't produce expected
results. Making the `#to_s` method here be sensible seems like a
cleaner fix than checking the class of an object to decide whether to
call `#value` in other places.

cc @codeclimate/review