### PR TITLE
Add engine.channel attribute

### DIFF
--- a/lib/cc/yaml/nodes/engine.rb
+++ b/lib/cc/yaml/nodes/engine.rb
@@ -2,11 +2,18 @@ module CC
   module Yaml
     module Nodes
       class Engine < Mapping
+        DEFAULT_CHANNEL = "stable".freeze
+
         map :enabled, to: Scalar[:bool], required: true
+        map :channel, to: Scalar
         map :checks, to: Checks
         map :config, to: EngineConfig
         map :exclude_fingerprints, to: Sequence
         map :exclude_paths, to: GlobList
+
+        def channel
+          self["channel"] || DEFAULT_CHANNEL
+        end
       end
     end
   end

--- a/spec/cc/yaml/nodes/engine_spec.rb
+++ b/spec/cc/yaml/nodes/engine_spec.rb
@@ -32,6 +32,27 @@ engines:
     json.must_equal %{{"enabled":true}}
   end
 
+  specify 'channel defaulted' do
+    config = CC::Yaml.parse! <<-YAML
+engines:
+  rubocop:
+    enabled: true
+    YAML
+
+    config.engines["rubocop"].channel.must_equal "stable"
+  end
+
+  specify 'channel present' do
+    config = CC::Yaml.parse! <<-YAML
+engines:
+  rubocop:
+    enabled: true
+    channel: beta
+    YAML
+
+    config.engines["rubocop"].channel.must_equal "beta"
+  end
+
   specify 'checks' do
     config = CC::Yaml.parse! <<-YAML
 engines:


### PR DESCRIPTION
- Will be used to select alternate engine images via config
- Defaults to "stable"

Note: I tried _extremely_ hard to get the supposedly built-in method of
defaulting values to work. It does not. The code we cargo-culted from
travis-ci/travis-yaml is old and bad.

/cc @codeclimate/review