### PR TITLE
Fix Sequence error bubbling behavior

### DIFF
--- a/lib/cc/yaml/nodes/dependencies.rb
+++ b/lib/cc/yaml/nodes/dependencies.rb
@@ -1,7 +1,7 @@
 module CC
   module Yaml
     module Nodes
-      class Dependencies < OpenMapping
+      class Dependencies < Mapping
         map :files, to: FileDependencyList
       end
     end

--- a/lib/cc/yaml/nodes/sequence.rb
+++ b/lib/cc/yaml/nodes/sequence.rb
@@ -75,7 +75,7 @@ module CC::Yaml
       def verify_children
         @children.delete_if do |child|
           next unless child.errors?
-          child.errors.each { |message| warning(message) }
+          child.errors.each { |message| error(message) }
           true
         end
       end

--- a/spec/cc/yaml/nodes/sequence_spec.rb
+++ b/spec/cc/yaml/nodes/sequence_spec.rb
@@ -8,13 +8,13 @@ module CC::Yaml::Nodes
       end
     end
 
-    it "warns for invalid data" do
-      example = parse_example(<<-EOYAML)
+    it "errors for invalid data" do
+      config = CC::Yaml.parse(<<-EOYAML)
         example:
           foo: bar
       EOYAML
 
-      example.warnings.must_equal(["unexpected mapping"])
+      config.errors.must_equal(["invalid \"example\" section: unexpected mapping"])
     end
 
     it "parses empty values" do

--- a/spec/cc/yaml_spec.rb
+++ b/spec/cc/yaml_spec.rb
@@ -15,6 +15,21 @@ describe CC::Yaml do
       config.errors.must_equal ["syntax error: (<unknown>): mapping values are not allowed in this context at line 1 column 27"]
       config.parseable?.must_equal false
     end
+
+    it "bubbles up dependency errors" do
+      config = CC::Yaml.parse(<<-YML)
+dependencies:
+  files:
+    - not://valid
+engines:
+  rubocop:
+    enabled: true
+YML
+
+      config.class.must_equal CC::Yaml::Nodes::Root
+      config.errors.must_equal ["invalid \"dependencies\" section: invalid \"files\" section: invalid URL: not://valid, missing key \"url\", missing key \"path\""]
+      config.parseable?.must_equal true
+    end
   end
 
   describe ".parse!" do


### PR DESCRIPTION
The Sequence class bubbled up errors in its children as warnings, which I
believe to be incorrect.

I discovered this while testing the new `dependencies` config: I found that invalid entries in `files` did not result in the overall config having any errors, and as a result erroneously being considered valid.

cc @codeclimate/review