### PR TITLE
Allow sequences/open mappings to accept non-scalar values

### DIFF
--- a/lib/cc/yaml/nodes/mapping.rb
+++ b/lib/cc/yaml/nodes/mapping.rb
@@ -68,8 +68,6 @@ module CC::Yaml
         unless set_warnings(visitor, key, value)
           check_incompatibility(key)
           visit_key_value(visitor, key, value)
-        #else
-          #$stderr.puts "WARNINGS? self=#{warnings.inspect}"
         end
       end
 
@@ -127,9 +125,7 @@ module CC::Yaml
       def ==(other)
         other = other.mapping if other.is_a? Mapping
         if other.respond_to? :to_hash and other.to_hash.size == @mapping.size
-          other.to_hash.all? { |k, v|
-            #$stderr.puts "Mapping#== k = #{k.inspect} v = #{v.inspect}"
-            include?(k) and self[k] == v }
+          other.to_hash.all? { |k, v| include?(k) and self[k] == v }
         else
           false
         end

--- a/lib/cc/yaml/nodes/nested_config.rb
+++ b/lib/cc/yaml/nodes/nested_config.rb
@@ -3,19 +3,19 @@ module CC
     module Nodes
       class NestedConfig < OpenMapping
         def visit_key_value(visitor, key, value)
-          node = subnode_for_pair(key, value)
+          node = subnode_for_pair(visitor, key, value)
           assign_node_and_visit(node, key, value, visitor)
         end
 
         protected
 
-        def subnode_for_pair(key, value)
+        def subnode_for_pair(visitor, key, value)
           if value.is_a?(::Psych::Nodes::Mapping)
             NestedConfig.new(self)
           elsif value.is_a?(::Psych::Nodes::Sequence)
             Sequence.new(self)
           else
-            subnode_for_key(key)
+            subnode_for(visitor, key, value)
           end
         end
       end

--- a/lib/cc/yaml/nodes/open_mapping.rb
+++ b/lib/cc/yaml/nodes/open_mapping.rb
@@ -3,11 +3,12 @@ module CC::Yaml
     class OpenMapping < Mapping
       def self.default_type(identifier = nil)
         @default_type = Nodes[identifier] if identifier
-        @default_type ||= superclass.respond_to?(:default_type) ? superclass.default_type : Scalar
+        @default_type ||= superclass.respond_to?(:default_type) ? superclass.default_type : nil
       end
 
-      def self.subnode_for_key(key)
-        super(key) || default_type
+      def subnode_for(visitor, key, value)
+        klass = self.class.subnode_for_key(key) || self.class.default_type || visitor.node_wrapper_class(value)
+        klass.new(self)
       end
 
       def accept_key?(key)

--- a/lib/cc/yaml/nodes/sequence.rb
+++ b/lib/cc/yaml/nodes/sequence.rb
@@ -23,7 +23,6 @@ module CC::Yaml
       end
 
       def visit_scalar(visitor, type, value, implicit = true)
-        #$stderr.puts "sequence#visit_scalar value=#{value.inspect}"
         visit_child(visitor, value) if type != :null
       end
 
@@ -36,7 +35,6 @@ module CC::Yaml
           if self.class.type
             self.class.type.new(self)
           else
-            #$stderr.puts "visit_child new  wrapper value=#{value.inspect} class=#{visitor.node_wrapper_class(value)}"
             visitor.node_wrapper_class(value).new(self)
           end
         visitor.accept(child, value)

--- a/lib/cc/yaml/nodes/sequence.rb
+++ b/lib/cc/yaml/nodes/sequence.rb
@@ -11,7 +11,7 @@ module CC::Yaml
 
       def self.type(identifier = nil)
         @type = Nodes[identifier] if identifier
-        @type ||= superclass.respond_to?(:type) ? superclass.type : Scalar
+        @type ||= superclass.respond_to?(:type) ? superclass.type : nil
       end
 
       def prepare
@@ -23,6 +23,7 @@ module CC::Yaml
       end
 
       def visit_scalar(visitor, type, value, implicit = true)
+        #$stderr.puts "sequence#visit_scalar value=#{value.inspect}"
         visit_child(visitor, value) if type != :null
       end
 
@@ -31,7 +32,13 @@ module CC::Yaml
       end
 
       def visit_child(visitor, value)
-        child = self.class.type.new(self)
+        child =
+          if self.class.type
+            self.class.type.new(self)
+          else
+            #$stderr.puts "visit_child new  wrapper value=#{value.inspect} class=#{visitor.node_wrapper_class(value)}"
+            visitor.node_wrapper_class(value).new(self)
+          end
         visitor.accept(child, value)
         @children << child
       end

--- a/lib/cc/yaml/parser/psych.rb
+++ b/lib/cc/yaml/parser/psych.rb
@@ -160,6 +160,17 @@ module CC::Yaml
         end
       end
 
+      def node_wrapper_class(value)
+        case value
+        when ::Psych::Nodes::Scalar   then ::CC::Yaml::Nodes::Scalar
+        when ::Psych::Nodes::Mapping  then ::CC::Yaml::Nodes::OpenMapping
+        when ::Psych::Nodes::Sequence then ::CC::Yaml::Nodes::Sequence
+        when ::Psych::Nodes::Document then ::CC::Yaml::Nodes::OpenMapping
+        when ::Psych::Nodes::Stream   then ::CC::Yaml::Nodes::Sequence
+        else raise ArgumentError, "Can't coerce #{value.inspect}"
+        end
+      end
+
       def simple(value)
         case value
         when ::Psych::Nodes::Scalar   then value.value

--- a/spec/cc/yaml/nodes/engine_config_spec.rb
+++ b/spec/cc/yaml/nodes/engine_config_spec.rb
@@ -37,4 +37,58 @@ describe CC::Yaml::Nodes::EngineConfig do
     }
     parsed_config.must_equal(expected_config)
   end
+
+  it "parses a plain hash" do
+    parsed_yaml = CC::Yaml.parse <<-YAML
+    engines:
+      engine_name:
+        enabled: true
+        config:
+          foo: bar
+          baz: boo
+    YAML
+
+    parsed_config = parsed_yaml.engines["engine_name"].config
+    parsed_config.must_equal({
+      "foo" => "bar",
+      "baz" => "boo",
+    })
+  end
+
+  it "parses a string in a special way" do
+    parsed_yaml = CC::Yaml.parse <<-YAML
+    engines:
+      engine_name:
+        enabled: true
+        config: foobar
+    YAML
+
+    parsed_config = parsed_yaml.engines["engine_name"].config
+    parsed_config.must_equal({
+      "file" => "foobar",
+    })
+  end
+
+  it "parses a map with a complex array" do
+    parsed_yaml = CC::Yaml.parse <<-YAML
+    engines:
+      engine_name:
+        enabled: true
+        config:
+          languages:
+          - a:
+              doot: doot
+          - b
+          - c
+    YAML
+
+    parsed_config = parsed_yaml.engines["engine_name"].config
+    parsed_config.must_equal({
+      "languages" => [
+        { "a" => { "doot" => "doot" } },
+        "b",
+        "c",
+      ]
+    })
+  end
 end

--- a/spec/cc/yaml/nodes/open_mapping_spec.rb
+++ b/spec/cc/yaml/nodes/open_mapping_spec.rb
@@ -1,0 +1,43 @@
+require "spec_helper"
+
+module CC::Yaml::Nodes
+  describe OpenMapping do
+    def setup
+      Root.class_eval do
+        map :example, to: OpenMapping
+      end
+    end
+
+    it "parses a hash" do
+      config = parse_example(<<-EOYAML)
+        example:
+          foo: bar
+          baz: 123
+      EOYAML
+
+      config.must_equal({ foo: "bar", baz: "123" })
+    end
+
+    it "parses a sub-hash" do
+      config = parse_example(<<-EOYAML)
+        example:
+          foo:
+            bar: booboo
+          baz: 123
+      EOYAML
+
+      config.must_equal({
+        foo: { bar: "booboo" },
+        baz: "123"
+      })
+    end
+
+    it "parses empty values" do
+      parse_example("example:").must_equal({})
+    end
+
+    def parse_example(yaml)
+      CC::Yaml.parse(yaml).example
+    end
+  end
+end

--- a/spec/cc/yaml/nodes/sequence_spec.rb
+++ b/spec/cc/yaml/nodes/sequence_spec.rb
@@ -8,13 +8,14 @@ module CC::Yaml::Nodes
       end
     end
 
-    it "errors for invalid data" do
+    it "parses a single hash value" do
       config = CC::Yaml.parse(<<-EOYAML)
         example:
           foo: bar
       EOYAML
 
-      config.errors.must_equal(["invalid \"example\" section: unexpected mapping"])
+      expected = { "foo" => "bar" }
+      config.example.must_equal([{ "foo" => "bar" }])
     end
 
     it "parses empty values" do
@@ -38,6 +39,22 @@ module CC::Yaml::Nodes
       EOYAML
 
       example.must_equal(["foo", "bar", "baz"])
+    end
+
+    it "parses complex arrays" do
+      example = parse_example(<<-EOYAML)
+        example:
+        - foo: 123
+        - bar:
+            baz: foo
+        - buzz
+      EOYAML
+
+      example.must_equal([
+        { "foo" => "123" },
+        { "bar" => { "baz" => "foo" } },
+        "buzz",
+      ])
     end
 
     def parse_example(yaml)

--- a/spec/valid_yaml_spec.rb
+++ b/spec/valid_yaml_spec.rb
@@ -19,12 +19,28 @@ engines:
       things:
       - one
       - two
+  duplication:
+    enabled: true
+    config:
+      languages:
+        ruby:
+          mass_threshold: 20
+        python:
+  weirdo:
+    enabled: false
+    config:
+      thing:
+      - hash:
+          key: foo
+      - 2
+      - bar
 checkout_submodules: true
 ratings:
   paths:
   - "**.rb"
 exclude_paths:
 - "spec/**/*"
+- "**/path.rb"
 YAML
   end
 


### PR DESCRIPTION
The change made in #34 revealed some previously hidden iffy behavior, where configs wouldn't support non-scalar values in generic `Sequence` or `OpenMapping` node.

For example:

```
languages:
- ruby:
  mass_threshold: 25
- javascript
```

Would get turned into `languages: ["javascript"]` in Ruby.

The change in #34 exposed this because it started raising an error for that case instead of silently parsing it, but that config *should* be perfectly parseasble for cases where we don't require an array to contain a certain type.

This PR improves this behavior for both `Sequence` and `OpenMapping` nodes (i.e. arrays and hashes without explicit type restrictions) so that they will correctly parse non-scalar child values.

The commits are messy, and I'll clean those up, but the code itself is ok right now, I think. I've tried to increase spec coverage more broadly as well.

cc @codeclimate/review 