### PR TITLE
Catch correct URI exception

### DIFF
--- a/lib/cc/yaml/nodes/file_dependency.rb
+++ b/lib/cc/yaml/nodes/file_dependency.rb
@@ -39,7 +39,7 @@ module CC
         def valid_url?(url)
           uri = URI.parse(url)
           uri.is_a?(URI::HTTP) || uri.is_a?(URI::HTTPS)
-        rescue URI::InvalidUriError
+        rescue URI::InvalidURIError
           false
         end
 

--- a/spec/cc/yaml/nodes/file_dependency_spec.rb
+++ b/spec/cc/yaml/nodes/file_dependency_spec.rb
@@ -46,7 +46,15 @@ describe CC::Yaml::Nodes::FileDependency do
   describe "validations" do
     it "validates url" do
       config = CC::Yaml.parse(<<-EOYAML)
-        example: "not://valid"
+        example: "%%not-a-url"
+      EOYAML
+
+      config.errors[0].must_match(/invalid URL/)
+    end
+
+    it "validates url schema" do
+      config = CC::Yaml.parse(<<-EOYAML)
+        example: "ftp://example.com/path"
       EOYAML
 
       config.errors[0].must_match(/invalid URL/)


### PR DESCRIPTION
There was a capitalization mistake in the execption name, and my test
 was accidentally testing a different aspect of the validation.

 I've fixed the exeption name, and reworked the tests to cover both
 cases.

cc @codeclimate/review