### PR TITLE
Handle invalid ratings.paths elements

### DIFF
--- a/lib/cc/yaml/nodes/glob.rb
+++ b/lib/cc/yaml/nodes/glob.rb
@@ -7,7 +7,8 @@ module CC
         end
 
         def value
-          @value.sub(%r{\*\*([^\/]*)?$}, "**/*\\1") # normalize glob format: app/** => app/**/* and **.rb => **/*.rb
+          # normalize glob format: app/** => app/**/* and **.rb => **/*.rb
+          @value && @value.sub(%r{\*\*([^\/]*)?$}, "**/*\\1")
         end
       end
     end

--- a/lib/cc/yaml/nodes/glob_list.rb
+++ b/lib/cc/yaml/nodes/glob_list.rb
@@ -3,6 +3,10 @@ module CC
     module Nodes
       class GlobList < Sequence
         type Glob
+
+        def allow_child?(child)
+          !child.value.nil?
+        end
       end
     end
   end

--- a/lib/cc/yaml/nodes/sequence.rb
+++ b/lib/cc/yaml/nodes/sequence.rb
@@ -38,7 +38,16 @@ module CC::Yaml
             visitor.node_wrapper_class(value).new(self)
           end
         visitor.accept(child, value)
-        @children << child
+
+        if allow_child?(child)
+          @children << child
+        else
+          warning("Discarding invalid value for %s: %s", self.class, child.value.inspect)
+        end
+      end
+
+      def allow_child?(*)
+        true
       end
 
       def nested_warnings(*prefix)

--- a/spec/cc/yaml/nodes/ratings_spec.rb
+++ b/spec/cc/yaml/nodes/ratings_spec.rb
@@ -1,0 +1,18 @@
+require "spec_helper"
+
+describe CC::Yaml::Nodes::Ratings do
+  specify "with an invalid path, it drops nil values with a warning" do
+    config = CC::Yaml.parse <<-YAML
+      ratings:
+        paths:
+        - []
+        - wut/*
+    YAML
+
+    config.ratings.paths.must_equal(["wut/*"])
+    config.nested_warnings.first.must_equal([
+      ["ratings", "paths"],
+      "Discarding invalid value for CC::Yaml::Nodes::GlobList: nil",
+    ])
+  end
+end


### PR DESCRIPTION
An invalid config such as:

```yaml
ratings:
 paths:
 - []
```

generates an error when we attempt to normalize globs via String#sub:

https://app.bugsnag.com/code-climate/builder/errors/58aed7a2f5919292da12f777


This is because the Array is not validated or discarded, it's silently made nil.

You might think you could address this simply within GlobList: just say hey,
this is an unexpected element type, maybe you should warn or error or do
something other than silently "cast" to nil. You might've even expected that'd
be the default behavior for the Sequence super class. Hell, you might've
thought guarding against unexpected element types is the whole damn point of
this library... You'd be wrong.

Commits:

- Avoid NoMethodError in Glob#value

  An invalid type, such as

      ratings:
       paths:
       - []

  results in a nil value in the node class. Trying to sub this nil triggers a
  NoMethodError. This patch passes the nil along instead.

- Provide a way to discard children in Sequence

  In Sequences, any type can be accepted as a child -- apparently. You might
  think that the declared element type would be enforced, but no, this library
  doesn't really work... At all, really. Anyway, this workaround will allow us
  to be stricter in cases where it matters, without changing things more
  broadly which has unknown risk.

- Disallow nil elements in GlobLists

- Add spec for invalid ratings.paths elements