### PR TITLE
Add engine issue_override support

### DIFF
--- a/lib/cc/yaml/nodes.rb
+++ b/lib/cc/yaml/nodes.rb
@@ -11,6 +11,7 @@ module CC
       autoload :FetchList, "cc/yaml/nodes/fetch_list"
       autoload :Glob, "cc/yaml/nodes/glob"
       autoload :GlobList, "cc/yaml/nodes/glob_list"
+      autoload :IssueOverride, "cc/yaml/nodes/issue_override"
       autoload :LanguageList, "cc/yaml/nodes/language_list"
       autoload :Mapping, "cc/yaml/nodes/mapping"
       autoload :NestedConfig, "cc/yaml/nodes/nested_config"
@@ -20,6 +21,7 @@ module CC
       autoload :Root, "cc/yaml/nodes/root"
       autoload :Scalar, "cc/yaml/nodes/scalar"
       autoload :Sequence, "cc/yaml/nodes/sequence"
+      autoload :Severity, "cc/yaml/nodes/severity"
 
       def self.[](key)
         return key if key.respond_to? :new

--- a/lib/cc/yaml/nodes/engine.rb
+++ b/lib/cc/yaml/nodes/engine.rb
@@ -10,6 +10,7 @@ module CC
         map :config, to: EngineConfig
         map :exclude_fingerprints, to: Sequence
         map :exclude_paths, to: GlobList
+        map :issue_override, to: IssueOverride
 
         def channel
           self["channel"] || DEFAULT_CHANNEL

--- a/lib/cc/yaml/nodes/issue_override.rb
+++ b/lib/cc/yaml/nodes/issue_override.rb
@@ -1,0 +1,9 @@
+module CC
+  module Yaml
+    module Nodes
+      class IssueOverride < Mapping
+        map :severity, to: Severity
+      end
+    end
+  end
+end

--- a/lib/cc/yaml/nodes/severity.rb
+++ b/lib/cc/yaml/nodes/severity.rb
@@ -1,0 +1,26 @@
+module CC
+  module Yaml
+    module Nodes
+      class Severity < Scalar
+        SEVERITIES = [
+          "info".freeze,
+          "minor".freeze,
+          "major".freeze,
+          "critical".freeze,
+          "blocker".freeze
+        ].freeze
+
+        def value=(value)
+          unless value.nil?
+            normalized_value = value.to_s.strip.downcase
+            if SEVERITIES.include? normalized_value
+              @value = normalized_value
+            else
+              error("Unexpected severity %s", value.inspect)
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/cc/yaml/nodes/engine_spec.rb
+++ b/spec/cc/yaml/nodes/engine_spec.rb
@@ -126,4 +126,16 @@ engines:
       "**/*.ex"
     ])
   end
+
+  specify "issue_override" do
+    config = CC::Yaml.parse! <<-YAML
+engines:
+  rubocop:
+    enabled: true
+    issue_override:
+      severity: info
+    YAML
+    engine = config.engines["rubocop"]
+    engine.issue_override.must_equal("severity" => "info")
+  end
 end

--- a/spec/cc/yaml/nodes/issue_override_spec.rb
+++ b/spec/cc/yaml/nodes/issue_override_spec.rb
@@ -1,0 +1,15 @@
+require 'spec_helper'
+
+describe CC::Yaml::Nodes::IssueOverride do
+  specify 'severity' do
+    config = CC::Yaml.parse! <<-YAML
+engines:
+  rubocop:
+    enabled: true
+    issue_override:
+      severity: info
+    YAML
+    engine = config.engines["rubocop"]
+    engine.issue_override.severity.must_equal "info"
+  end
+end

--- a/spec/cc/yaml/nodes/severity_spec.rb
+++ b/spec/cc/yaml/nodes/severity_spec.rb
@@ -1,0 +1,41 @@
+require "spec_helper"
+
+describe CC::Yaml::Nodes::Severity do
+  it "normalizes value" do
+    config = CC::Yaml.parse <<-YAML
+      engines:
+        rubocop:
+          enabled: true
+          issue_override:
+            severity: Major
+    YAML
+
+    config.engines["rubocop"].issue_override.severity.must_equal "major"
+  end
+
+   %w[info minor major critical blocker].each do |severity|
+    it "assepts #{severity}" do
+      config = CC::Yaml.parse <<-YAML
+        engines:
+          rubocop:
+            enabled: true
+            issue_override:
+              severity: #{severity}
+      YAML
+
+      config.engines["rubocop"].issue_override.severity.must_equal severity
+      config.errors.must_equal []
+    end
+   end
+
+  specify "with invalid data, emits an error" do
+    config = CC::Yaml.parse <<-YAML
+      engines:
+        rubocop:
+          enabled: true
+          issue_override:
+            severity: "RED ALERT!!!"
+    YAML
+    config.errors.must_include %(invalid "engines" section: invalid "rubocop" section: invalid "issue_override" section: invalid "severity" section: Unexpected severity "RED ALERT!!!")
+  end
+end


### PR DESCRIPTION
In preparation for a new CC CLI feature the config needs to be expanded.

CC CLI will soon be able to override severity of issues emitted by the engine.

One use case is lowering engine to all-info issues. This is useful when new engines are introduced to a big old codebase. One would want to see issues to be able to fix them but they won't block ongoing work. The effort to eliminate all the issues at once might be substantial. It's much more tenable to gradually fix them as the regular work continues.
